### PR TITLE
Add support for custom (non-ppa) installs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ cd src
 # Run a local analysis
 mkdir output
 .\Run.ps1 unzip -ResultsDirectory output
+
+# Run a custom package (arbitrary install)
+.\Run.ps1 -PackageName nodejs -PackageVersion 17.8.0 -InstallCommand "wget 'https://nodejs.org/download/release/v17.8.0/node-v17.8.0-linux-x64.tar.gz' && tar zxvf node-v17.8.0-linux-x64.tar.gz" -ResultsDirectory output
 ```
 
 # About Alpha-Omega

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -6,8 +6,8 @@ LABEL schema-version="1.0"
 LABEL name="omega-tracer"
 LABEL maintainer="Open Source Security Foundation - Omega"
 LABEL vendor="OpenSSF"
-LABEL build-date="2022-07-17T00:00:00.00Z"
-LABEL version="0.1.0"
+LABEL build-date="2022-07-21T00:00:00.00Z"
+LABEL version="0.1.1"
 
 # Initialize some things
 ARG DEBIAN_FRONTEND=noninteractive
@@ -26,7 +26,7 @@ RUN echo 'Acquire::Check-Valid-Until false;' >> /etc/apt/apt.conf.d/10-nocheckva
 # Core utilities
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y strace dos2unix file apt-mirror
+    apt-get install -y strace dos2unix file apt-mirror curl wget
 
 # Set up local mirror
 RUN echo "deb [trusted=yes] file:/opt/apt-mirror/mirror/archive.ubuntu.com/ubuntu jammy main restricted" > /etc/apt/sources-local.list && \
@@ -52,5 +52,8 @@ RUN dos2unix /usr/bin/trace.sh \
              /usr/bin/get-package-list.sh && \
     chmod +x /usr/bin/trace.sh \
              /usr/bin/get-package-list.sh
+
+# Store all executables (to allow us to identify new binaries after custom builds)
+RUN find / -path /sys -prune -o -path /proc -prune -o -path /opt -prune -o -type f -perm /u=x,g=x,o=x | xargs file | grep executable | grep ELF | cut -d: -f1 | xargs shasum -a 256 | sort > /opt/shasums.txt 2>/dev/null
 
 ENTRYPOINT ["/usr/bin/trace.sh"]

--- a/src/Run.ps1
+++ b/src/Run.ps1
@@ -56,7 +56,6 @@ if (!$ForceAnalyze) {
         $ExportPrefix = "_"
     }
     $FinalDirectory = (Join-Path (Join-Path $ResultsDirectory $ExportPrefix) $PackageName)
-    Write-Output $FinalDirectory
 
     if (Test-Path -Type Container $FinalDirectory) {
         Write-Host "Package [$PackageName] already analyzed."


### PR DESCRIPTION
This PR improves support for custom installs.

First, during the image build, we capture the hashes of all executable files present.

Then, after the custom install completes, we look for any new/modified files, and use those as the entrypoint list.